### PR TITLE
Fix button styling on the protected resource button.

### DIFF
--- a/ckanext/protected_resources/templates/package/snippets/lock_resource_button.html
+++ b/ckanext/protected_resources/templates/package/snippets/lock_resource_button.html
@@ -6,5 +6,5 @@
 {% else %}
     {% set action_path = 'protected_resource.lock' if  h.check_ckan_version('2.9') else 'protected_resource_lock' %}
     {% set resource_url = h.url_for(action_path, dataset_id=resource.package_id, resource_id=resource.id) %}
-    <a class="btn" href="{{resource_url}}"><i class="fa fa-lock fa-lg"></i> Lock Resource</a>
+    <a class="btn btn-default" href="{{resource_url}}"><i class="fa fa-lock fa-lg"></i> Lock Resource</a>
 {% endif %}


### PR DESCRIPTION
Fixes how the protected resources button was displayed. It now appears as a button and not just a link.